### PR TITLE
sound: clear the value on level_bar when stream is empty

### DIFF
--- a/panels/sound/cc-level-bar.c
+++ b/panels/sound/cc-level-bar.c
@@ -232,6 +232,7 @@ cc_level_bar_set_stream (CcLevelBar     *self,
 
   if (stream == NULL)
    {
+     self->value = 0.0;
      gtk_widget_queue_draw (GTK_WIDGET (self));
      return;
    }


### PR DESCRIPTION
We met an Input Device level_bar display issue on a machine which has
no internal mic. At first there is no external mic plugged, so the
Input Device list is empty and level_bar is gray color, after we plug
an external mic, the level_bar has red color ripples, then we unplug
the external mic, the Input Device list changes to empty and we
expect the level_bar changes back to gray color, but some bars are
still red color.

Here clear the self->value to 0 if the stream is empty, then the
level_bar will change back to gray color when Input/Output device
list is empty.

Signed-off-by: Hui Wang <hui.wang@canonical.com>