### PR TITLE
Remove Python from dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,11 +33,6 @@ enable_tracing = get_option('tracing')
 
 config_h = configuration_data()
 
-py = import('python')
-python = py.find_installation('python3')
-
-config_h.set_quoted('TEST_NM_PYTHON', python.path())
-
 # defines
 set_defines = [
   # package


### PR DESCRIPTION
## Description

Just removes the make dependency on Python, because it isn't being used for anything.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
