### PR TITLE
Update background preview to look more like Budgie

### DIFF
--- a/panels/background/cc-background-preview.ui
+++ b/panels/background/cc-background-preview.ui
@@ -38,7 +38,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="shadow-type">none</property>
-                <property name="valign">start</property>
+                <property name="valign">end</property>
                 <style>
                   <class name="desktop-preview" />
                 </style>
@@ -49,17 +49,11 @@
                     <property name="can-focus">False</property>
 
                     <child>
-                      <object class="GtkLabel">
+                      <object class="GtkImage">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Activities</property>
-                      </object>
-                    </child>
-
-                    <child type="center">
-                      <object class="GtkLabel" id="desktop_clock_label">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="icon-name">start-here-symbolic</property>
+                        <property name="pixel-size">6</property>
                       </object>
                     </child>
 
@@ -93,6 +87,13 @@
                             <property name="can-focus">False</property>
                             <property name="icon-name">battery-low-symbolic</property>
                             <property name="pixel-size">6</property>
+                          </object>
+                        </child>
+
+                        <child type="center">
+                          <object class="GtkLabel" id="desktop_clock_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                           </object>
                         </child>
                       </object>


### PR DESCRIPTION
## Description

Changes the preview frame under Background from this:
![image](https://user-images.githubusercontent.com/12981608/189774460-9d3f8304-2422-43e1-aaeb-37fa85642c7d.png)

to this:
![image](https://user-images.githubusercontent.com/12981608/189774390-71e5efa4-6bca-4e4f-8ed4-ed0bee4b6a18.png)

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
