### PR TITLE
Add click method to touchpad settings

### DIFF
--- a/panels/mouse/cc-mouse-panel.c
+++ b/panels/mouse/cc-mouse-panel.c
@@ -59,6 +59,7 @@ struct _CcMousePanel
   GtkSwitch         *touchpad_natural_scrolling_switch;
   GtkListBoxRow     *touchpad_speed_row;
   GtkScale          *touchpad_speed_scale;
+  GtkComboBox       *touchpad_click_method_box;
   GtkSwitch         *touchpad_toggle_switch;
   GtkListBoxRow     *two_finger_scrolling_row;
   GtkSwitch         *two_finger_scrolling_switch;
@@ -291,6 +292,10 @@ setup_dialog (CcMousePanel *self)
                    gtk_range_get_adjustment (GTK_RANGE (self->touchpad_speed_scale)), "value",
                    G_SETTINGS_BIND_DEFAULT);
 
+  g_settings_bind (self->touchpad_settings, "click-method",
+                   self->touchpad_click_method_box, "active-id",
+                   G_SETTINGS_BIND_DEFAULT);
+
   g_settings_bind (self->touchpad_settings, "tap-to-click",
                    self->tap_to_click_switch, "active",
                    G_SETTINGS_BIND_DEFAULT);
@@ -443,6 +448,7 @@ cc_mouse_panel_class_init (CcMousePanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_natural_scrolling_switch);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_speed_row);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_speed_scale);
+  gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_click_method_box);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_toggle_switch);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, two_finger_scrolling_row);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, two_finger_scrolling_switch);

--- a/panels/mouse/cc-mouse-panel.ui
+++ b/panels/mouse/cc-mouse-panel.ui
@@ -284,6 +284,28 @@
                           </object>
                         </child>
                         <child>
+                          <object class="HdyActionRow" id="touchpad_click_method_row">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="activatable">false</property>
+                            <property name="title" translatable="yes">Click Method Profile</property>
+                            <property name="subtitle" translatable="yes">How different mouse clicks (e.g. left and right) are registered.</property>
+                            <child>
+                              <object class="GtkComboBoxText" id="touchpad_click_method_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="valign">center</property>
+                                <items>
+                                  <item id="default" translatable="yes">Hardware Default</item>
+                                  <item id="none" translatable="yes">None</item>
+                                  <item id="areas" translatable="yes">Pressed Area</item>
+                                  <item id="fingers" translatable="yes">Number of Fingers</item>
+                                </items>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
                           <object class="HdyActionRow" id="tap_to_click_row">
                             <property name="visible">False</property>
                             <property name="can_focus">True</property>


### PR DESCRIPTION
## Description

This setting allows the user to change how different types of mouse clicks are emulated on a touchpad, and is a simple mapping of a (probably long-existing) dconf property.

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
