### PR TITLE
Add keybind for the Budgie Power Dialog

### DIFF
--- a/panels/keyboard/01-budgie.xml.in
+++ b/panels/keyboard/01-budgie.xml.in
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<KeyListEntries group="system" schema="com.solus-project.budgie-wm" name="System">
+
+  <KeyListEntry name="show-power-dialog" description="Show the Power Dialog"/>
+
+</KeyListEntries>

--- a/panels/keyboard/meson.build
+++ b/panels/keyboard/meson.build
@@ -18,6 +18,7 @@ i18n.merge_file(
 
 xml_files = [
   '00-multimedia.xml',
+  '01-budgie.xml',
   '01-input-sources.xml',
   '01-launchers.xml',
   '01-screenshot.xml',


### PR DESCRIPTION
## Description
Add a keybind for the Budgie Power Dialog in the System section.

Ref https://github.com/BuddiesOfBudgie/budgie-desktop/pull/244

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
