### PR TITLE
Add support for switching the file manager

### DIFF
--- a/panels/default-apps/cc-default-apps-panel.c
+++ b/panels/default-apps/cc-default-apps-panel.c
@@ -41,6 +41,7 @@ struct _CcDefaultAppsPanel
   GtkWidget *default_apps_grid;
 
   GtkWidget *web_label;
+  GtkWidget *files_label;
   GtkWidget *mail_label;
   GtkWidget *calendar_label;
   GtkWidget *music_label;
@@ -154,6 +155,7 @@ info_panel_setup_default_app (CcDefaultAppsPanel *self,
 
 static DefaultAppData preferred_app_infos[] = {
   { "x-scheme-handler/http", OFFSET (web_label), "text/html;application/xhtml+xml;x-scheme-handler/https" },
+  { "inode/directory", OFFSET (files_label), NULL },
   { "x-scheme-handler/mailto", OFFSET (mail_label), NULL },
   { "text/calendar", OFFSET (calendar_label), NULL },
   { "audio/x-vorbis+ogg", OFFSET (music_label), "audio/*" },
@@ -181,6 +183,7 @@ cc_default_apps_panel_class_init (CcDefaultAppsPanelClass *klass)
   gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/default-apps/cc-default-apps-panel.ui");
   gtk_widget_class_bind_template_child (widget_class, CcDefaultAppsPanel, default_apps_grid);
   gtk_widget_class_bind_template_child (widget_class, CcDefaultAppsPanel, web_label);
+  gtk_widget_class_bind_template_child (widget_class, CcDefaultAppsPanel, files_label);
   gtk_widget_class_bind_template_child (widget_class, CcDefaultAppsPanel, mail_label);
   gtk_widget_class_bind_template_child (widget_class, CcDefaultAppsPanel, calendar_label);
   gtk_widget_class_bind_template_child (widget_class, CcDefaultAppsPanel, music_label);

--- a/panels/default-apps/cc-default-apps-panel.ui
+++ b/panels/default-apps/cc-default-apps-panel.ui
@@ -36,6 +36,22 @@
               </object>
             </child>
             <child>
+              <object class="GtkLabel" id="files_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">1</property>
+                <property name="label" translatable="yes">_Files</property>
+                <property name="use_underline">True</property>
+                <style>
+                 <class name="dim-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="left_attach">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="mail_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -47,7 +63,7 @@
                 </style>
               </object>
               <packing>
-                <property name="top_attach">1</property>
+                <property name="top_attach">2</property>
                 <property name="left_attach">0</property>
               </packing>
             </child>
@@ -63,7 +79,7 @@
                 </style>
               </object>
               <packing>
-                <property name="top_attach">2</property>
+                <property name="top_attach">3</property>
                 <property name="left_attach">0</property>
               </packing>
             </child>
@@ -79,7 +95,7 @@
                 </style>
               </object>
               <packing>
-                <property name="top_attach">3</property>
+                <property name="top_attach">4</property>
                 <property name="left_attach">0</property>
               </packing>
             </child>
@@ -95,7 +111,7 @@
                 </style>
               </object>
               <packing>
-                <property name="top_attach">4</property>
+                <property name="top_attach">5</property>
                 <property name="left_attach">0</property>
               </packing>
             </child>
@@ -166,12 +182,23 @@
                 </style>
               </object>
               <packing>
-                <property name="top_attach">5</property>
+                <property name="top_attach">6</property>
                 <property name="left_attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label33">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label">    </property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label34">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label">    </property>


### PR DESCRIPTION
## Description
Adds the file manager to the list of default applications to switch. Not sure if there is a better label name and anything else to add to the `prefered_app_infos` entry. Feedback welcome

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
