### PR TITLE
WIP: Add a panel to configure budgie-desktop-view

### DIFF
--- a/panels/desktop-icons/budgie-desktop-icons-panel.desktop.in.in
+++ b/panels/desktop-icons/budgie-desktop-icons-panel.desktop.in.in
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=Desktop Icons
+Comment=Configure Desktop Icons
+Exec=budgie-control-center desktop-icons
+# Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+Icon=org.buddiesofbudgie.Settings-desktop-icons-symbolic
+Terminal=false
+Type=Application
+NoDisplay=true
+StartupNotify=true
+Categories=GNOME;GTK;Settings;X-GNOME-Settings-Panel;X-GNOME-DetailsSettings;
+OnlyShowIn=Budgie;
+# Translators: Search terms to find the Default Applications panel. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+Keywords=desktop;icons;

--- a/panels/desktop-icons/cc-desktop-icons-panel.c
+++ b/panels/desktop-icons/cc-desktop-icons-panel.c
@@ -1,0 +1,142 @@
+/* cc-desktop-icons-panel.c
+ *
+ * Copyright 2023 Elliot <BlindRepublic@mailo.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <shell/cc-shell.h>
+#include <shell/cc-object-storage.h>
+
+#include "cc-desktop-icons-panel.h"
+#include "cc-desktop-icons-resources.h"
+
+struct _CcDesktopIconsPanel {
+	CcPanel  parent_instance;
+
+  GtkSwitch *enable_switch;
+  GtkBox    *header_box;
+
+  GtkSwitch *home_switch;
+  GtkSwitch *trash_switch;
+  GtkSwitch *mounts_switch;
+
+  GtkComboBoxText *click_policy_combo;
+  GtkComboBoxText *icon_size_combo;
+
+  GSettings *settings;
+};
+
+CC_PANEL_REGISTER (CcDesktopIconsPanel, cc_desktop_icons_panel)
+
+static void
+cc_desktop_icons_panel_constructed (GObject *object)
+{
+  CcDesktopIconsPanel *panel = CC_DESKTOP_ICONS_PANEL (object);
+
+  G_OBJECT_CLASS (cc_desktop_icons_panel_parent_class)->constructed (object);
+
+  g_settings_bind (panel->settings,
+                   "show",
+                   panel->enable_switch,
+                   "active",
+                   G_SETTINGS_BIND_DEFAULT);
+
+  g_object_bind_property (panel->enable_switch,
+                          "active",
+                          panel,
+                          "sensitive",
+                          G_BINDING_SYNC_CREATE);
+
+
+  cc_shell_embed_widget_in_header (cc_panel_get_shell (CC_PANEL (panel)),
+  									               GTK_WIDGET (panel->header_box), GTK_POS_RIGHT);
+}
+
+static void
+cc_desktop_icons_panel_finalize (GObject *object)
+{
+	CcDesktopIconsPanel *panel = CC_DESKTOP_ICONS_PANEL (object);
+
+  g_clear_object (&panel->settings);
+
+	G_OBJECT_CLASS (cc_desktop_icons_panel_parent_class)->finalize (object);
+}
+
+static void
+cc_desktop_icons_panel_class_init (CcDesktopIconsPanelClass *klass)
+{
+  GObjectClass *object_class   = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+  CcPanelClass *panel_class    = CC_PANEL_CLASS (klass);
+
+  object_class->constructed = cc_desktop_icons_panel_constructed;
+  object_class->finalize    = cc_desktop_icons_panel_finalize;
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/control-center/desktop-icons/cc-desktop-icons-panel.ui");
+
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, enable_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, header_box);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, home_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, trash_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, mounts_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, click_policy_combo);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, icon_size_combo);
+}
+
+static void
+cc_desktop_icons_panel_init (CcDesktopIconsPanel *panel)
+{
+  g_resources_register (cc_desktop_icons_get_resource ());
+
+  panel->settings = g_settings_new ("org.buddiesofbudgie.budgie-desktop-view");
+
+  gtk_widget_init_template (GTK_WIDGET (panel));
+
+  g_settings_bind (panel->settings,
+                   "show-home-folder",
+                   panel->home_switch,
+                   "active",
+                   G_SETTINGS_BIND_DEFAULT);
+
+  g_settings_bind (panel->settings,
+                   "show-trash-folder",
+                   panel->trash_switch,
+                   "active",
+                   G_SETTINGS_BIND_DEFAULT);
+
+  g_settings_bind (panel->settings,
+                   "show-active-mounts",
+                   panel->mounts_switch,
+                   "active",
+                   G_SETTINGS_BIND_DEFAULT);
+
+  g_settings_bind (panel->settings,
+                   "click-policy",
+                   panel->click_policy_combo,
+                   "active-id",
+                   G_SETTINGS_BIND_DEFAULT);
+
+  g_settings_bind (panel->settings,
+                   "icon-size",
+                   panel->icon_size_combo,
+                   "active-id",
+                   G_SETTINGS_BIND_DEFAULT);
+}

--- a/panels/desktop-icons/cc-desktop-icons-panel.c
+++ b/panels/desktop-icons/cc-desktop-icons-panel.c
@@ -23,16 +23,29 @@
 #endif
 
 #include <shell/cc-shell.h>
+#include <shell/cc-application.h>
 #include <shell/cc-object-storage.h>
+
+#include <handy.h>
 
 #include "cc-desktop-icons-panel.h"
 #include "cc-desktop-icons-resources.h"
+
+typedef enum {
+  DESKTOP_TYPE_NONE,
+  DESKTOP_TYPE_BUDGIE,
+  DESKTOP_TYPE_DESKTOPFOLDER,
+  DESKTOP_TYPE_NEMO
+} DesktopType;
 
 struct _CcDesktopIconsPanel {
 	CcPanel  parent_instance;
 
   GtkSwitch *enable_switch;
   GtkBox    *header_box;
+
+  HdyPreferencesGroup *directories_group;
+  HdyPreferencesGroup *icons_group;
 
   GtkSwitch *home_switch;
   GtkSwitch *trash_switch;
@@ -41,7 +54,8 @@ struct _CcDesktopIconsPanel {
   GtkComboBoxText *click_policy_combo;
   GtkComboBoxText *icon_size_combo;
 
-  GSettings *settings;
+  DesktopType desktop_type;
+  GSettings  *settings;
 };
 
 CC_PANEL_REGISTER (CcDesktopIconsPanel, cc_desktop_icons_panel)
@@ -50,11 +64,23 @@ static void
 cc_desktop_icons_panel_constructed (GObject *object)
 {
   CcDesktopIconsPanel *panel = CC_DESKTOP_ICONS_PANEL (object);
+  gchar               *show_setting;
 
   G_OBJECT_CLASS (cc_desktop_icons_panel_parent_class)->constructed (object);
 
+  if (panel->desktop_type == DESKTOP_TYPE_BUDGIE)
+    show_setting = "show";
+
+  else if (panel->desktop_type == DESKTOP_TYPE_DESKTOPFOLDER)
+    show_setting = "show-desktopfolder";
+
+  else if (panel->desktop_type == DESKTOP_TYPE_NEMO)
+    show_setting = "show-desktop-icons";
+
+  else return;
+
   g_settings_bind (panel->settings,
-                   "show",
+                   show_setting,
                    panel->enable_switch,
                    "active",
                    G_SETTINGS_BIND_DEFAULT);
@@ -73,11 +99,11 @@ cc_desktop_icons_panel_constructed (GObject *object)
 static void
 cc_desktop_icons_panel_finalize (GObject *object)
 {
-	CcDesktopIconsPanel *panel = CC_DESKTOP_ICONS_PANEL (object);
+  CcDesktopIconsPanel *panel = CC_DESKTOP_ICONS_PANEL (object);
 
   g_clear_object (&panel->settings);
 
-	G_OBJECT_CLASS (cc_desktop_icons_panel_parent_class)->finalize (object);
+  G_OBJECT_CLASS (cc_desktop_icons_panel_parent_class)->finalize (object);
 }
 
 static void
@@ -94,6 +120,8 @@ cc_desktop_icons_panel_class_init (CcDesktopIconsPanelClass *klass)
 
   gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, enable_switch);
   gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, header_box);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, directories_group);
+  gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, icons_group);
   gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, home_switch);
   gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, trash_switch);
   gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, mounts_switch);
@@ -101,42 +129,123 @@ cc_desktop_icons_panel_class_init (CcDesktopIconsPanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcDesktopIconsPanel, icon_size_combo);
 }
 
+static DesktopType
+get_desktop_type (void) {
+  DesktopType desktop_type;
+  GSettings  *wm_settings;
+  gchar      *path;
+
+  wm_settings = g_settings_new ("com.solus-project.budgie-wm");
+  desktop_type = g_settings_get_enum (wm_settings, "desktop-type-override");
+
+  g_object_unref (wm_settings);
+  if (desktop_type != DESKTOP_TYPE_NONE && desktop_type != DESKTOP_TYPE_BUDGIE)
+    {
+      gchar *program = desktop_type == DESKTOP_TYPE_DESKTOPFOLDER ? "com.github.spheras.desktopfolder" : "nemo-desktop";
+
+      if ((path = g_find_program_in_path (program)))
+        {
+          g_free (path);
+          return desktop_type;
+        }
+    }
+
+  if ((path = g_find_program_in_path ("org.buddiesofbudgie.budgie-desktop-view")))
+    {
+      g_free (path);
+      return DESKTOP_TYPE_BUDGIE;
+    }
+
+  return DESKTOP_TYPE_NONE;
+}
+
 static void
 cc_desktop_icons_panel_init (CcDesktopIconsPanel *panel)
 {
+
   g_resources_register (cc_desktop_icons_get_resource ());
-
-  panel->settings = g_settings_new ("org.buddiesofbudgie.budgie-desktop-view");
-
   gtk_widget_init_template (GTK_WIDGET (panel));
 
-  g_settings_bind (panel->settings,
-                   "show-home-folder",
-                   panel->home_switch,
-                   "active",
-                   G_SETTINGS_BIND_DEFAULT);
+  panel->desktop_type = get_desktop_type ();
 
-  g_settings_bind (panel->settings,
-                   "show-trash-folder",
-                   panel->trash_switch,
-                   "active",
-                   G_SETTINGS_BIND_DEFAULT);
+  if (panel->desktop_type == DESKTOP_TYPE_BUDGIE)
+    {
+      panel->settings = g_settings_new ("org.buddiesofbudgie.budgie-desktop-view");
 
-  g_settings_bind (panel->settings,
-                   "show-active-mounts",
-                   panel->mounts_switch,
-                   "active",
-                   G_SETTINGS_BIND_DEFAULT);
+      g_settings_bind (panel->settings,
+                       "show-home-folder",
+                       panel->home_switch,
+                       "active",
+                       G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind (panel->settings,
-                   "click-policy",
-                   panel->click_policy_combo,
-                   "active-id",
-                   G_SETTINGS_BIND_DEFAULT);
+      g_settings_bind (panel->settings,
+                       "show-trash-folder",
+                       panel->trash_switch,
+                       "active",
+                       G_SETTINGS_BIND_DEFAULT);
 
-  g_settings_bind (panel->settings,
-                   "icon-size",
-                   panel->icon_size_combo,
-                   "active-id",
-                   G_SETTINGS_BIND_DEFAULT);
+      g_settings_bind (panel->settings,
+                       "show-active-mounts",
+                       panel->mounts_switch,
+                       "active",
+                       G_SETTINGS_BIND_DEFAULT);
+
+      g_settings_bind (panel->settings,
+                       "click-policy",
+                       panel->click_policy_combo,
+                       "active-id",
+                       G_SETTINGS_BIND_DEFAULT);
+
+      g_settings_bind (panel->settings,
+                       "icon-size",
+                       panel->icon_size_combo,
+                       "active-id",
+                       G_SETTINGS_BIND_DEFAULT);
+
+    }
+  else 
+    {
+      gtk_widget_hide (GTK_WIDGET (panel->icons_group));
+
+      if (panel->desktop_type == DESKTOP_TYPE_NEMO)
+        {
+          panel->settings = g_settings_new ("org.nemo.desktop");
+
+          g_settings_bind (panel->settings,
+                          "home-icon-visible",
+                          panel->home_switch,
+                          "active",
+                          G_SETTINGS_BIND_DEFAULT);
+
+          g_settings_bind (panel->settings,
+                           "trash-icon-visible",
+                           panel->trash_switch,
+                           "active",
+                           G_SETTINGS_BIND_DEFAULT);
+
+          g_settings_bind (panel->settings,
+                           "volumes-visible",
+                           panel->mounts_switch,
+                           "active",
+                           G_SETTINGS_BIND_DEFAULT);
+        }
+      else
+        {
+          gtk_widget_hide (GTK_WIDGET (panel->directories_group));
+
+          if (panel->desktop_type == DESKTOP_TYPE_DESKTOPFOLDER)
+            panel->settings = g_settings_new ("com.github.spheras.desktopfolder");
+
+          else
+            gtk_widget_set_sensitive (panel->enable_switch, FALSE);
+        }
+    }
+}
+
+void
+cc_desktop_icons_panel_static_init_func (void)
+{
+  if (get_desktop_type () == DESKTOP_TYPE_NONE)
+    cc_shell_model_set_panel_visibility (cc_application_get_model (CC_APPLICATION (g_application_get_default ())),
+                                         "desktop-icons", FALSE);
 }

--- a/panels/desktop-icons/cc-desktop-icons-panel.h
+++ b/panels/desktop-icons/cc-desktop-icons-panel.h
@@ -1,0 +1,30 @@
+/* cc-desktop-icons-panel.h
+ *
+ * Copyright 2023 Elliot <BlindRepublic@mailo.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <shell/cc-shell.h>
+
+G_BEGIN_DECLS
+
+#define CC_TYPE_DESKTOP_ICONS_PANEL (cc_desktop_icons_panel_get_type ())
+G_DECLARE_FINAL_TYPE (CcDesktopIconsPanel, cc_desktop_icons_panel, CC, DESKTOP_ICONS_PANEL, CcPanel)
+
+G_END_DECLS

--- a/panels/desktop-icons/cc-desktop-icons-panel.ui
+++ b/panels/desktop-icons/cc-desktop-icons-panel.ui
@@ -27,7 +27,7 @@
       <object class="HdyPreferencesPage">
         <property name="visible">True</property>
         <child>
-          <object class="HdyPreferencesGroup">
+          <object class="HdyPreferencesGroup" id="directories_group">
             <property name="visible">True</property>
 	          <property name="title" translatable="yes">Directories to Show</property>
 	          <child>
@@ -181,7 +181,7 @@
           </object>
         </child>
         <child>
-          <object class="HdyPreferencesGroup">
+          <object class="HdyPreferencesGroup" id="icons_group">
             <property name="visible">True</property>
             <property name="title">Icons</property>
             <child>

--- a/panels/desktop-icons/cc-desktop-icons-panel.ui
+++ b/panels/desktop-icons/cc-desktop-icons-panel.ui
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <object class="GtkBox" id="header_box">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkSwitch" id="enable_switch">
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="valign">center</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="padding">4</property>
+        <property name="pack_type">end</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
+  <template class="CcDesktopIconsPanel" parent="CcPanel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="HdyPreferencesPage">
+        <property name="visible">True</property>
+        <child>
+          <object class="HdyPreferencesGroup">
+            <property name="visible">True</property>
+	          <property name="title" translatable="yes">Directories to Show</property>
+	          <child>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="selection-mode">none</property>
+                <style>
+                  <class name="content"/>
+                </style>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="selectable">False</property>
+                    <property name="activatable">False</property>
+                    <style>
+                      <class name="content"/>
+                    </style>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Home</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="home_switch">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="selectable">False</property>
+                    <property name="activatable">False</property>
+                    <style>
+                      <class name="content"/>
+                    </style>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Trash</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="trash_switch">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="selectable">False</property>
+                    <property name="activatable">False</property>
+                    <style>
+                      <class name="content"/>
+                    </style>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Active Mounts</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="mounts_switch">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="HdyPreferencesGroup">
+            <property name="visible">True</property>
+            <property name="title">Icons</property>
+            <child>
+              <object class="GtkListBox">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="selection-mode">none</property>
+                <style>
+                  <class name="content"/>
+                </style>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="selectable">False</property>
+                    <property name="activatable">False</property>
+                    <style>
+                      <class name="content"/>
+                    </style>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Click Policy</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="click_policy_combo">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <items>
+                              <item translatable="yes" id="single">Single</item>
+                              <item translatable="yes" id="double">Double</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="selectable">False</property>
+                    <property name="activatable">False</property>
+                    <style>
+                      <class name="content"/>
+                    </style>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Icon Size</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="icon_size_combo">
+                            <property name="visible">True</property>
+                            <property name="margin_start">12</property>
+                            <property name="margin_end">12</property>
+                            <property name="margin_top">12</property>
+                            <property name="margin_bottom">12</property>
+                            <items>
+                              <item translatable="yes" id="small">Small</item>
+                              <item translatable="yes" id="normal">Normal</item>
+                              <item translatable="yes" id="large">Large</item>
+                              <item translatable="yes" id="massive">Massive</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/panels/desktop-icons/desktop-icons.gresource.xml
+++ b/panels/desktop-icons/desktop-icons.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+    <gresource prefix="/org/gnome/control-center/desktop-icons">
+    <file preprocess="xml-stripblanks">cc-desktop-icons-panel.ui</file>
+  </gresource>
+</gresources>

--- a/panels/desktop-icons/meson.build
+++ b/panels/desktop-icons/meson.build
@@ -1,0 +1,37 @@
+panels_list += cappletname
+desktop = 'budgie-@0@-panel.desktop'.format(cappletname)
+
+desktop_in = configure_file(
+  input: desktop + '.in.in',
+  output: desktop + '.in',
+  configuration: desktop_conf
+)
+
+i18n.merge_file(
+  type: 'desktop',
+  input: desktop_in,
+  output: desktop,
+  po_dir: po_dir,
+  install: true,
+  install_dir: control_center_desktopdir
+)
+
+sources = files('cc-desktop-icons-panel.c')
+
+resource_data = files('cc-desktop-icons-panel.ui')
+
+sources += gnome.compile_resources(
+  'cc-' + cappletname + '-resources',
+  cappletname + '.gresource.xml',
+  c_name: 'cc_' + cappletname.underscorify (),
+  dependencies: resource_data,
+  export: true
+)
+
+panels_libs += static_library(
+  cappletname,
+  sources: sources,
+  include_directories: top_inc,
+  dependencies: deps,
+  c_args: cflags
+)

--- a/panels/meson.build
+++ b/panels/meson.build
@@ -7,6 +7,7 @@ panels = [
   'color',
   'datetime',
   'default-apps',
+  'desktop-icons',
   'diagnostics',
   'display',
   'info-overview',

--- a/shell/cc-panel-list.c
+++ b/shell/cc-panel-list.c
@@ -385,6 +385,7 @@ static const gchar * const panel_order[] = {
   "mobile-broadband",
   "bluetooth",
   "background",
+  "desktop-icons",
   "notifications",
   "search",
   "multitasking",

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -73,9 +73,11 @@ extern GType cc_camera_panel_get_type (void);
 extern GType cc_microphone_panel_get_type (void);
 extern GType cc_usage_panel_get_type (void);
 extern GType cc_diagnostics_panel_get_type (void);
+extern GType cc_desktop_icons_panel_get_type (void);
 
 /* Static init functions */
 extern void cc_diagnostics_panel_static_init_func (void);
+extern void cc_desktop_icons_panel_static_init_func (void);
 #ifdef BUILD_THUNDERBOLT
 extern void cc_thunderbolt_panel_static_init_func (void);
 #endif /* BUILD_THUNDERBOLT */
@@ -108,7 +110,7 @@ static CcPanelLoaderVtable default_panels[] =
   PANEL_TYPE("color",            cc_color_panel_get_type,                NULL),
   PANEL_TYPE("datetime",         cc_date_time_panel_get_type,            NULL),
   PANEL_TYPE("default-apps",     cc_default_apps_panel_get_type,         NULL),
-  PANEL_TYPE("desktop-icons",     cc_desktop_icons_panel_get_type,         NULL),
+  PANEL_TYPE("desktop-icons",     cc_desktop_icons_panel_get_type,         cc_desktop_icons_panel_static_init_func),
   PANEL_TYPE("diagnostics",      cc_diagnostics_panel_get_type,          cc_diagnostics_panel_static_init_func),
   PANEL_TYPE("display",          cc_display_panel_get_type,              NULL),
   PANEL_TYPE("info-overview",    cc_info_overview_panel_get_type,        NULL),

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -39,6 +39,7 @@ extern GType cc_bluetooth_panel_get_type (void);
 extern GType cc_color_panel_get_type (void);
 extern GType cc_date_time_panel_get_type (void);
 extern GType cc_default_apps_panel_get_type (void);
+extern GType cc_desktop_icons_panel_get_type (void);
 extern GType cc_display_panel_get_type (void);
 extern GType cc_info_overview_panel_get_type (void);
 extern GType cc_keyboard_panel_get_type (void);
@@ -107,6 +108,7 @@ static CcPanelLoaderVtable default_panels[] =
   PANEL_TYPE("color",            cc_color_panel_get_type,                NULL),
   PANEL_TYPE("datetime",         cc_date_time_panel_get_type,            NULL),
   PANEL_TYPE("default-apps",     cc_default_apps_panel_get_type,         NULL),
+  PANEL_TYPE("desktop-icons",     cc_desktop_icons_panel_get_type,         NULL),
   PANEL_TYPE("diagnostics",      cc_diagnostics_panel_get_type,          cc_diagnostics_panel_static_init_func),
   PANEL_TYPE("display",          cc_display_panel_get_type,              NULL),
   PANEL_TYPE("info-overview",    cc_info_overview_panel_get_type,        NULL),


### PR DESCRIPTION
## Description
Adds a panel to configure basic settings for `budgie-desktop-view` similar to that of Budgie Desktop Settings. This is not final as I don't know how to handle the category and icon for the settings list button. I really just based this off of the original settings page and what I could gleam from other pages in this application, so all feedback is welcome.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
