### PR TITLE
Add the ability to toggle disabling touchpad whilst typing

### DIFF
--- a/panels/mouse/cc-mouse-panel.c
+++ b/panels/mouse/cc-mouse-panel.c
@@ -61,6 +61,8 @@ struct _CcMousePanel
   GtkScale          *touchpad_speed_scale;
   GtkComboBox       *touchpad_click_method_box;
   GtkSwitch         *touchpad_toggle_switch;
+  GtkListBoxRow     *touchpad_typing_row;
+  GtkSwitch         *touchpad_typing_switch;
   GtkListBoxRow     *two_finger_scrolling_row;
   GtkSwitch         *two_finger_scrolling_switch;
 
@@ -254,6 +256,12 @@ setup_dialog (CcMousePanel *self)
                                 touchpad_enabled_set_mapping,
                                 NULL, NULL);
   g_settings_bind_with_mapping (self->touchpad_settings, "send-events",
+                                self->touchpad_typing_row, "sensitive",
+                                G_SETTINGS_BIND_GET,
+                                touchpad_enabled_get_mapping,
+                                touchpad_enabled_set_mapping,
+                                NULL, NULL);
+  g_settings_bind_with_mapping (self->touchpad_settings, "send-events",
                                 self->touchpad_natural_scrolling_row, "sensitive",
                                 G_SETTINGS_BIND_GET,
                                 touchpad_enabled_get_mapping,
@@ -307,6 +315,10 @@ setup_dialog (CcMousePanel *self)
   g_settings_bind (self->touchpad_settings, "edge-scrolling-enabled",
                    self->edge_scrolling_switch, "state",
                    G_SETTINGS_BIND_GET);
+
+  g_settings_bind (self->touchpad_settings, "disable-while-typing",
+                   self->touchpad_typing_switch, "active",
+                   G_SETTINGS_BIND_DEFAULT);
 
   setup_touchpad_options (self);
 }
@@ -450,6 +462,8 @@ cc_mouse_panel_class_init (CcMousePanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_speed_scale);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_click_method_box);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_toggle_switch);
+  gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_typing_row);
+  gtk_widget_class_bind_template_child (widget_class, CcMousePanel, touchpad_typing_switch);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, two_finger_scrolling_row);
   gtk_widget_class_bind_template_child (widget_class, CcMousePanel, two_finger_scrolling_switch);
 

--- a/panels/mouse/cc-mouse-panel.ui
+++ b/panels/mouse/cc-mouse-panel.ui
@@ -244,6 +244,22 @@
                           </object>
                         </child>
                         <child>
+                          <object class="HdyActionRow" id="touchpad_typing_row">
+                              <property name="visible">True</property>
+                              <property name="can_focus">True</property>
+                              <property name="activatable">false</property>
+                              <property name="title" translatable="yes">Disable Touchpad While Typing</property>
+                              <child>
+                                <object class="GtkSwitch" id="touchpad_typing_switch">
+                                  <property name="visible">True</property>
+                                  <property name="can_focus">True</property>
+                                  <property name="halign">end</property>
+                                  <property name="valign">center</property>
+                                </object>
+                              </child>
+                          </object>
+                        </child>
+                        <child>
                           <object class="HdyActionRow" id="touchpad_natural_scrolling_row">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>

--- a/po/budgie-control-center.pot
+++ b/po/budgie-control-center.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: budgie-control-center 1.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-20 22:20+0100\n"
+"POT-Creation-Date: 2023-12-23 16:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -600,7 +600,7 @@ msgstr ""
 msgid "_Close"
 msgstr ""
 
-#: panels/wacom/cc-wacom-panel.c:477 panels/mouse/cc-mouse-panel.ui.h:28
+#: panels/wacom/cc-wacom-panel.c:477 panels/mouse/cc-mouse-panel.ui.h:29
 msgid "Test Your _Settings"
 msgstr ""
 
@@ -7455,42 +7455,46 @@ msgid "Touchpad"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:18
-msgid "Touchpad Speed"
+msgid "Disable Touchpad While Typing"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:19
-msgid "Touchpad Click Method"
+msgid "Touchpad Speed"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:20
-msgid "Create button behavior (left, middle and right) using the chosen action."
+msgid "Touchpad Click Method"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:21
-msgid "Use the touchpad default"
+msgid "Create button behavior (left, middle and right) using the chosen action."
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:22
-msgid "No buttons created"
+msgid "Use the touchpad default"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:23
-msgid "Left, middle and right areas"
+msgid "No buttons created"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:24
-msgid "One, two and three fingers"
+msgid "Left, middle and right areas"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:25
-msgid "Tap to Click"
+msgid "One, two and three fingers"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:26
-msgid "Two-finger Scrolling"
+msgid "Tap to Click"
 msgstr ""
 
 #: panels/mouse/cc-mouse-panel.ui.h:27
+msgid "Two-finger Scrolling"
+msgstr ""
+
+#: panels/mouse/cc-mouse-panel.ui.h:28
 msgid "Edge Scrolling"
 msgstr ""
 


### PR DESCRIPTION
## Description
add a switch to control whether to disable the touchpad whilst typing.

Similar to the method added to gnome-control-center here https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/1998

![image](https://github.com/BuddiesOfBudgie/budgie-control-center/assets/996240/4a9b1a73-d534-435c-a623-32a2960a0691)

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-control-center and verified that the patch worked (if needed)
