### PR TITLE
support both sshd socket and services for remote login

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -191,6 +191,11 @@ endif
 config_h.set('HAVE_CHEESE', enable_cheese,
              description: 'Define to 1 to enable cheese webcam support')
 
+# Remote login use SOCKET based SSH instead of starting 'eagerly'
+enable_sshsocket = get_option('ssh')
+config_h.set('HAVE_SSHSOCKET', enable_sshsocket,
+             description: 'Define to 1 to enable ssh socket connections')
+
 # IBus support
 enable_ibus = get_option('ibus')
 if enable_ibus

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('ssh', type: 'boolean', value: false, description: 'build with SSH Socket based connection for remote login')
 option('cheese', type: 'boolean', value: true, description: 'build with cheese webcam support')
 option('documentation', type: 'boolean', value: false, description: 'build documentation')
 option('ibus', type: 'boolean', value: true, description: 'build with IBus support')

--- a/panels/sharing/cc-remote-login-helper.c
+++ b/panels/sharing/cc-remote-login-helper.c
@@ -25,6 +25,10 @@
 #define SSHD_SERVICE "sshd.service"
 #endif
 
+#ifndef SSHD_SOCKET
+#define SSHD_SOCKET "sshd.socket"
+#endif
+
 int
 main (int    argc,
       char **argv)
@@ -39,9 +43,16 @@ main (int    argc,
     {
       g_autoptr(GError) error = NULL;
 
-      if (!cc_enable_service (SSHD_SERVICE, G_BUS_TYPE_SYSTEM, &error))
+      /* on <=jammy we want to ensure the socket is disabled and enable the
+         service to match the default behaviour */
+      if (!cc_disable_service (SSHD_SOCKET, G_BUS_TYPE_SYSTEM, &error))
         {
           g_critical ("Failed to enable %s: %s", SSHD_SERVICE, error->message);
+          return EXIT_FAILURE;
+        }
+      else if (!cc_enable_service (SSHD_SERVICE, G_BUS_TYPE_SYSTEM, &error))
+        {
+          g_critical ("Failed to enable %s: %s", SSHD_SOCKET, error->message);
           return EXIT_FAILURE;
         }
       else
@@ -55,7 +66,12 @@ main (int    argc,
 
       if (!cc_disable_service (SSHD_SERVICE, G_BUS_TYPE_SYSTEM, &error))
         {
-          g_critical ("Failed to enable %s: %s", SSHD_SERVICE, error->message);
+          g_critical ("Failed to disable %s: %s", SSHD_SERVICE, error->message);
+          return EXIT_FAILURE;
+        }
+      else if (!cc_disable_service (SSHD_SOCKET, G_BUS_TYPE_SYSTEM, &error))
+        {
+          g_critical ("Failed to disable %s: %s", SSHD_SOCKET, error->message);
           return EXIT_FAILURE;
         }
       else

--- a/panels/sharing/cc-remote-login-helper.c
+++ b/panels/sharing/cc-remote-login-helper.c
@@ -43,7 +43,25 @@ main (int    argc,
     {
       g_autoptr(GError) error = NULL;
 
-      /* on <=jammy we want to ensure the socket is disabled and enable the
+#ifdef HAVE_SSHSOCKET
+      /* for socket based connection ensure the service is disabled and enable the
+         socket to match the default behaviour */
+      if (!cc_disable_service (SSHD_SERVICE, G_BUS_TYPE_SYSTEM, &error))
+        {
+          g_critical ("Failed to enable %s: %s", SSHD_SOCKET, error->message);
+          return EXIT_FAILURE;
+        }
+      else if (!cc_enable_service (SSHD_SOCKET, G_BUS_TYPE_SYSTEM, &error))
+        {
+          g_critical ("Failed to enable %s: %s", SSHD_SERVICE, error->message);
+          return EXIT_FAILURE;
+        }
+      else
+        {
+          return EXIT_SUCCESS;
+        }
+#else
+      /* default is to ensure the socket is disabled and enable the
          service to match the default behaviour */
       if (!cc_disable_service (SSHD_SOCKET, G_BUS_TYPE_SYSTEM, &error))
         {
@@ -59,6 +77,7 @@ main (int    argc,
         {
           return EXIT_SUCCESS;
         }
+#endif
     }
   else if (g_str_equal (argv[1], "disable"))
     {

--- a/panels/sharing/cc-remote-login.c
+++ b/panels/sharing/cc-remote-login.c
@@ -25,14 +25,79 @@
 #define SSHD_SERVICE "sshd.service"
 #endif
 
+#ifndef SSHD_SOCKET
+#define SSHD_SOCKET "sshd.socket"
+#endif
+
+typedef enum {
+  SYSTEMD_UNIT_UNKNOWN,
+  SYSTEMD_UNIT_SSHD_SERVICE,
+  SYSTEMD_UNIT_SSHD_SOCKET,
+} SystemdUnit;
+
+typedef enum {
+  SYSTEMD_SERVICE_STATE_UNKNOWN,
+  SYSTEMD_SERVICE_STATE_DISABLED,
+  SYSTEMD_SERVICE_STATE_ENABLED_AND_ACTIVE,
+} SystemdServiceState;
+
+typedef struct
+{
+  SystemdUnit unit;
+  SystemdServiceState state;
+} SystemdService;
+
+#define CONTAINER_OF(ptr, type, member) \
+  ((type *) ((guint8 *) (ptr) - G_STRUCT_OFFSET (type, member)))
+
+#define SYSTEMD_SERVICE_UNIT_NAME(service) \
+  ((service)->unit == SYSTEMD_UNIT_SSHD_SERVICE ? SSHD_SERVICE : \
+  (service)->unit == SYSTEMD_UNIT_SSHD_SOCKET ? SSHD_SOCKET : "UNKNOWN")
+
 typedef struct
 {
   GtkSwitch    *gtkswitch;
   GtkWidget    *button;
   GCancellable *cancellable;
+  SystemdService sshd_service;
+  SystemdService sshd_socket;
 } CallbackData;
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (CallbackData, g_free)
+
+static void
+systemd_service_cleanup (SystemdService *service)
+{
+  CallbackData *callback_data;
+
+  if (service->unit == SYSTEMD_UNIT_SSHD_SERVICE)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_service);
+    }
+  else if (service->unit == SYSTEMD_UNIT_SSHD_SOCKET)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_socket);
+    }
+  else
+    {
+      g_assert_not_reached ();
+    }
+
+  service->unit = SYSTEMD_UNIT_UNKNOWN;
+
+  if (callback_data->sshd_service.unit == SYSTEMD_UNIT_UNKNOWN &&
+      callback_data->sshd_socket.unit == SYSTEMD_UNIT_UNKNOWN)
+    {
+      g_free(callback_data);
+    }
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (SystemdService, systemd_service_cleanup)
+
+static void
+state_ready_callback (GObject      *source_object,
+                      GAsyncResult *result,
+                      gpointer      user_data);
 
 static void
 set_switch_state (GtkSwitch *gtkswitch,
@@ -52,7 +117,8 @@ active_state_ready_callback (GObject      *source_object,
                              GAsyncResult *result,
                              gpointer      user_data)
 {
-  g_autoptr(CallbackData) callback_data = user_data;
+  CallbackData *callback_data;
+  g_autoptr(SystemdService) service = user_data;
   g_autoptr(GVariant) active_variant = NULL;
   g_autoptr(GVariant) child_variant = NULL;
   g_autoptr(GVariant) tmp_variant = NULL;
@@ -75,15 +141,51 @@ active_state_ready_callback (GObject      *source_object,
       return;
     }
 
+  if (service->unit == SYSTEMD_UNIT_SSHD_SERVICE)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_service);
+    }
+  else if (service->unit == SYSTEMD_UNIT_SSHD_SOCKET)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_socket);
+    }
+  else
+    {
+      g_assert_not_reached ();
+    }
+
   child_variant = g_variant_get_child_value (active_variant, 0);
   tmp_variant = g_variant_get_variant (child_variant);
   active_state = g_variant_get_string (tmp_variant, NULL);
 
   active = g_str_equal (active_state, "active");
 
-  /* set the switch to the correct state */
-  if (callback_data->gtkswitch)
-    set_switch_state (callback_data->gtkswitch, active);
+  if (active)
+    {
+      g_debug ("%s is active...", SYSTEMD_SERVICE_UNIT_NAME (service));
+      service->state = SYSTEMD_SERVICE_STATE_ENABLED_AND_ACTIVE;
+    }
+  else
+    {
+      g_debug ("%s is not active...", SYSTEMD_SERVICE_UNIT_NAME (service));
+      service->state = SYSTEMD_SERVICE_STATE_DISABLED;
+    }
+
+  /* if we now have states for both the service and the socket, then we can
+   * set the switch state */
+  if (callback_data->sshd_service.state != SYSTEMD_SERVICE_STATE_UNKNOWN &&
+      callback_data->sshd_socket.state != SYSTEMD_SERVICE_STATE_UNKNOWN)
+    {
+      gboolean active = (callback_data->sshd_service.state == SYSTEMD_SERVICE_STATE_ENABLED_AND_ACTIVE ||
+                         callback_data->sshd_socket.state == SYSTEMD_SERVICE_STATE_ENABLED_AND_ACTIVE);
+
+      /* set the switch to the correct state */
+      if (callback_data->gtkswitch)
+        {
+          g_debug ("Setting switch state for %s: %d", SYSTEMD_SERVICE_UNIT_NAME (service), active);
+          set_switch_state (callback_data->gtkswitch, active);
+        }
+    }
 }
 
 static void
@@ -91,11 +193,25 @@ path_ready_callback (GObject      *source_object,
                      GAsyncResult *result,
                      gpointer      user_data)
 {
-  g_autoptr(CallbackData) callback_data = user_data;
+  CallbackData *callback_data;
+  g_autoptr(SystemdService) service = user_data;
   g_autoptr(GVariant) path_variant = NULL;
   g_autoptr(GVariant) child_variant = NULL;
   const gchar *object_path;
   g_autoptr(GError) error = NULL;
+
+  if (service->unit == SYSTEMD_UNIT_SSHD_SERVICE)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_service);
+    }
+  else if (service->unit == SYSTEMD_UNIT_SSHD_SOCKET)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_socket);
+    }
+  else
+    {
+      g_assert_not_reached ();
+    }
 
   path_variant = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source_object),
                                                 result, &error);
@@ -110,7 +226,10 @@ path_ready_callback (GObject      *source_object,
 
       /* hide the remote login button, since the service is not available */
       if (callback_data->button)
-        gtk_widget_hide (callback_data->button);
+        {
+          g_debug ("Setting button visibility FALSE for %s", SYSTEMD_SERVICE_UNIT_NAME (service));
+          gtk_widget_hide (callback_data->button);
+        }
 
       return;
     }
@@ -131,8 +250,8 @@ path_ready_callback (GObject      *source_object,
                           -1,
                           callback_data->cancellable,
                           active_state_ready_callback,
-                          callback_data);
-  g_steal_pointer (&callback_data);
+                          service);
+  g_steal_pointer (&service);
 }
 
 static void
@@ -140,11 +259,25 @@ state_ready_callback (GObject      *source_object,
                       GAsyncResult *result,
                       gpointer      user_data)
 {
-  g_autoptr(CallbackData) callback_data = user_data;
+  CallbackData *callback_data;
+  g_autoptr(SystemdService) service = user_data;
   g_autoptr(GVariant) state_variant = NULL;
   g_autoptr(GVariant) child_variant = NULL;
   const gchar *state_string;
   g_autoptr(GError) error = NULL;
+
+  if (service->unit == SYSTEMD_UNIT_SSHD_SERVICE)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_service);
+    }
+  else if (service->unit == SYSTEMD_UNIT_SSHD_SOCKET)
+    {
+      callback_data = CONTAINER_OF (service, CallbackData, sshd_socket);
+    }
+  else
+    {
+      g_assert_not_reached ();
+    }
 
   state_variant = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source_object),
                                                  result, &error);
@@ -168,30 +301,46 @@ state_ready_callback (GObject      *source_object,
 
   if (g_str_equal (state_string, "enabled"))
     {
+      g_debug ("%s is enabled - checking if running...", SYSTEMD_SERVICE_UNIT_NAME (service));
       /* service is enabled, so check whether it is running or not */
       g_dbus_connection_call (G_DBUS_CONNECTION (source_object),
                               "org.freedesktop.systemd1",
                               "/org/freedesktop/systemd1",
                               "org.freedesktop.systemd1.Manager",
                               "GetUnit",
-                              g_variant_new ("(s)", SSHD_SERVICE),
+                              g_variant_new ("(s)", SYSTEMD_SERVICE_UNIT_NAME (service)),
                               (GVariantType*) "(o)",
                               G_DBUS_CALL_FLAGS_NONE,
                               -1,
                               callback_data->cancellable,
                               path_ready_callback,
-                              callback_data);
-      g_steal_pointer (&callback_data);
+                              service);
+      g_steal_pointer (&service);
     }
   else if (g_str_equal (state_string, "disabled"))
     {
-      /* service is available, but is currently disabled */
-      set_switch_state (callback_data->gtkswitch, FALSE);
+      g_debug ("%s is disabled...", SYSTEMD_SERVICE_UNIT_NAME (service));
+      service->state = SYSTEMD_SERVICE_STATE_DISABLED;
+      /* if we now have states for both the service and the socket, then we can
+       * set the switch state */
+      if (callback_data->sshd_service.state != SYSTEMD_SERVICE_STATE_UNKNOWN &&
+          callback_data->sshd_socket.state != SYSTEMD_SERVICE_STATE_UNKNOWN)
+        {
+          gboolean active = (callback_data->sshd_service.state == SYSTEMD_SERVICE_STATE_ENABLED_AND_ACTIVE ||
+                             callback_data->sshd_socket.state == SYSTEMD_SERVICE_STATE_ENABLED_AND_ACTIVE);
+
+          /* set the switch to the correct state */
+          if (callback_data->gtkswitch)
+            {
+              g_debug ("Setting switch state for %s: %d", SYSTEMD_SERVICE_UNIT_NAME (service), active);
+              set_switch_state (callback_data->gtkswitch, active);
+            }
+        }
     }
   else
     {
       /* unknown state */
-      g_warning ("Unknown state %s for %s", state_string, SSHD_SERVICE);
+      g_warning ("Unknown state %s for %s", state_string, SYSTEMD_SERVICE_UNIT_NAME (service));
     }
 }
 
@@ -225,7 +374,19 @@ bus_ready_callback (GObject      *source_object,
                           -1,
                           callback_data->cancellable,
                           state_ready_callback,
-                          callback_data);
+                          &callback_data->sshd_service);
+  g_dbus_connection_call (connection,
+                          "org.freedesktop.systemd1",
+                          "/org/freedesktop/systemd1",
+                          "org.freedesktop.systemd1.Manager",
+                          "GetUnitFileState",
+                          g_variant_new ("(s)", SSHD_SOCKET),
+                          (GVariantType*) "(s)",
+                          G_DBUS_CALL_FLAGS_NONE,
+                          -1,
+                          callback_data->cancellable,
+                          state_ready_callback,
+                          &callback_data->sshd_socket);
   g_steal_pointer (&callback_data);
 }
 
@@ -243,6 +404,10 @@ cc_remote_login_get_enabled (GCancellable *cancellable,
   callback_data->gtkswitch = gtkswitch;
   callback_data->button = button;
   callback_data->cancellable = cancellable;
+  callback_data->sshd_service.unit = SYSTEMD_UNIT_SSHD_SERVICE;
+  callback_data->sshd_service.state = SYSTEMD_SERVICE_STATE_UNKNOWN;
+  callback_data->sshd_socket.unit = SYSTEMD_UNIT_SSHD_SOCKET;
+  callback_data->sshd_socket.state = SYSTEMD_SERVICE_STATE_UNKNOWN;
 
   g_bus_get (G_BUS_TYPE_SYSTEM, callback_data->cancellable,
              bus_ready_callback, callback_data);


### PR DESCRIPTION
## Description
original author Alex Murray <alex.murray@canonical.com> 
Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/gnome-control-center/+bug/2039577

To test:

without the patch install openssh-server
then in BCC - sharing - enable remote login

ssh to the remote host - this will work
then in BCC - sharing - disable remote login

ssh to the remote host - still can login remotely.  This is the CVE issue

install the patch and compile - remember to use those CPPFLAGS otherwise remote login row in BCC will disappear

Repeat the test above - ssh to the remote host will now be enabled/disabled depending upon whether the sharing is enabled/disabled as appropriate.

This is the patch Ubuntu will be including in 24.04.  Needs testing on other distros before merging.  Upstream (to-date) have not merged this patch.

NOTE: From upstream most distros use SSH 'eager' connections by default.  Ubuntu uses socket based connections.
Upstream are debating build (example code given) vs runtime support (without example code). So I've included the build approach via a meson option - eager based connections is the default, socket based distros such as ubuntu are the exception.

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-control-center and verified that the patch worked (if needed)
