### PR TITLE
Disable gnome-online-accounts due to latest upstream GOA changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,7 +112,7 @@ if not libhandy_dep.found()
   libhandy_dep = libhandy.get_variable('libhandy_dep')
 endif
 
-goa_req_version = '>= 3.25.3'
+#goa_req_version = '>= 3.25.3'
 pulse_req_version = '>= 2.0'
 
 accounts_dep = dependency('accountsservice', version: '>= 0.6.39')
@@ -122,7 +122,7 @@ gio_dep = dependency('gio-2.0')
 glib_dep = dependency('glib-2.0', version: '>= 2.70.0')
 gnome_desktop_dep = dependency('gnome-desktop-3.0', version: '>= 3.33.4')
 gnome_settings_dep = dependency('gnome-settings-daemon', version: '>= 3.27.90')
-goa_dep = dependency('goa-1.0', version: goa_req_version)
+#goa_dep = dependency('goa-1.0', version: goa_req_version)
 gsettings_desktop_dep = dependency('gsettings-desktop-schemas', version: '>= 42.alpha')
 libxml_dep = dependency('libxml-2.0')
 pulse_dep = dependency('libpulse', version: pulse_req_version)

--- a/panels/meson.build
+++ b/panels/meson.build
@@ -16,7 +16,6 @@ panels = [
   'mouse',
   'multitasking',
   'notifications',
-  'online-accounts',
   'power',
   'printers',
   'region',

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -49,7 +49,7 @@ extern GType cc_network_panel_get_type (void);
 extern GType cc_wifi_panel_get_type (void);
 #endif /* BUILD_NETWORK */
 extern GType cc_notifications_panel_get_type (void);
-extern GType cc_goa_panel_get_type (void);
+//extern GType cc_goa_panel_get_type (void);
 extern GType cc_power_panel_get_type (void);
 extern GType cc_printers_panel_get_type (void);
 extern GType cc_region_panel_get_type (void);
@@ -120,7 +120,7 @@ static CcPanelLoaderVtable default_panels[] =
   PANEL_TYPE("wifi",             cc_wifi_panel_get_type,                 cc_wifi_panel_static_init_func),
 #endif
   PANEL_TYPE("notifications",    cc_notifications_panel_get_type,        NULL),
-  PANEL_TYPE("online-accounts",  cc_goa_panel_get_type,                  NULL),
+  //PANEL_TYPE("online-accounts",  cc_goa_panel_get_type,                  NULL),
   PANEL_TYPE("power",            cc_power_panel_get_type,                NULL),
   PANEL_TYPE("printers",         cc_printers_panel_get_type,             NULL),
   PANEL_TYPE("region",           cc_region_panel_get_type,               NULL),


### PR DESCRIPTION
## Description
Lets just hide GOA compilation due to online accounts moving to GTK4/libadwaita which breaks GTK3 based forks such as BCC https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/issues/291

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-control-center and verified that the patch worked (if needed)
