### PR TITLE
Make the Location panel an optional panel

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -191,6 +191,10 @@ endif
 config_h.set('HAVE_CHEESE', enable_cheese,
              description: 'Define to 1 to enable cheese webcam support')
 
+enable_location = get_option('location')
+config_h.set('HAVE_LOCATION', enable_location,
+            description: 'Define to 1 to enable location support')
+
 # Remote login use SOCKET based SSH instead of starting 'eagerly'
 enable_sshsocket = get_option('ssh')
 config_h.set('HAVE_SSHSOCKET', enable_sshsocket,
@@ -327,4 +331,5 @@ summary({
   'IBus': enable_ibus,
   'Snap': enable_snap,
   'Malcontent': enable_malcontent,
+  'Location': enable_location,
 }, section: 'Optional Dependencies')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,4 @@ option('wayland', type: 'boolean', value: false, description: 'build with Waylan
 option('profile', type: 'combo', choices: ['default','development'], value: 'default')
 option('malcontent', type: 'boolean', value: false, description: 'build with malcontent support')
 option('dark_mode_distributor_logo', type: 'string', description: 'absolute path to distributor logo dark mode variant')
+option('location', type: 'boolean', value: false, description: 'build with mozilla based location support')

--- a/panels/meson.build
+++ b/panels/meson.build
@@ -11,7 +11,6 @@ panels = [
   'display',
   'info-overview',
   'keyboard',
-  'location',
   'microphone',
   'mouse',
   'multitasking',
@@ -27,6 +26,10 @@ panels = [
   'user-accounts',
   'wwan',
 ]
+
+if enable_location
+  panels += ['location']
+endif
 
 if host_is_linux
   panels += ['network']

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -67,7 +67,9 @@ extern GType cc_wacom_panel_get_type (void);
 #ifdef BUILD_WWAN
 extern GType cc_wwan_panel_get_type (void);
 #endif /* BUILD_WWAN */
+#ifdef HAVE_LOCATION
 extern GType cc_location_panel_get_type (void);
+#endif /* HAVE_LOCATION*/
 extern GType cc_camera_panel_get_type (void);
 extern GType cc_microphone_panel_get_type (void);
 extern GType cc_usage_panel_get_type (void);
@@ -111,7 +113,9 @@ static CcPanelLoaderVtable default_panels[] =
   PANEL_TYPE("display",          cc_display_panel_get_type,              NULL),
   PANEL_TYPE("info-overview",    cc_info_overview_panel_get_type,        NULL),
   PANEL_TYPE("keyboard",         cc_keyboard_panel_get_type,             NULL),
+#ifdef HAVE_LOCATION
   PANEL_TYPE("location",         cc_location_panel_get_type,             NULL),
+#endif
   //PANEL_TYPE("microphone",       cc_microphone_panel_get_type,           NULL),
   PANEL_TYPE("mouse",            cc_mouse_panel_get_type,                NULL),
   PANEL_TYPE("multitasking",     cc_multitasking_panel_get_type,         NULL),


### PR DESCRIPTION
## Description
Mozilla will deprecate its service at the end of March 2024. Thus location support will be broken until a replacement solution is found.
https://github.com/mozilla/ichnaea/issues/2065

This has been coded as a meson option rather than hard-coding the drop of the panel.  This allows later easier resurrection if a direct replacement service is enabled

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-control-center and verified that the patch worked (if needed)
