### PR TITLE
fix: FTBFS with -Wno-incompatible-pointer-types

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -77,7 +77,8 @@ if get_option('buildtype').contains('debug')
     '-Wmissing-prototypes',
     '-Wnested-externs',
     '-Wno-strict-aliasing',
-    '-Wno-sign-compare'
+    '-Wno-sign-compare',
+    '-Wno-incompatible-pointer-types'
   ]
 
   common_flags += cc.get_supported_arguments(test_cflags)

--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -959,7 +959,7 @@ set_current_output (CcDisplayPanel   *panel,
       if (cc_has_fractional_key())
         {
           lockdown=cc_display_config_get_fractional_scaling (panel->current_config);
-          gtk_widget_set_sensitive(panel->automatic_screen_lock_switch, !lockdown);
+          gtk_widget_set_sensitive(GTK_WIDGET (panel->automatic_screen_lock_switch), !lockdown);
         }
     }
 

--- a/panels/display/cc-display-settings.c
+++ b/panels/display/cc-display-settings.c
@@ -450,7 +450,7 @@ cc_display_settings_rebuild_ui (CcDisplaySettings *self)
                          cc_display_config_get_fractional_scaling (self->config));
 
   gtk_switch_set_active (GTK_SWITCH (self->scale_fractional_switch), cc_display_config_get_fractional_scaling (self->config));
-  gtk_widget_set_visible(self->scale_fractional_row, cc_has_fractional_key());
+  gtk_widget_set_visible(GTK_WIDGET (self->scale_fractional_row), cc_has_fractional_key());
 
   gtk_widget_set_visible (self->underscanning_row,
                           cc_display_monitor_supports_underscanning (self->selected_output) &&

--- a/panels/sound/cc-sound-panel.c
+++ b/panels/sound/cc-sound-panel.c
@@ -300,7 +300,7 @@ cc_sound_panel_init (CcSoundPanel *self)
                            G_CONNECT_SWAPPED);
   allow_amplified_changed_cb (self);
 
-  gtk_widget_set_visible(self->budgie_output_listbox, TRUE);
+  gtk_widget_set_visible(GTK_WIDGET (self->budgie_output_listbox), TRUE);
   gtk_widget_set_visible(GTK_WIDGET (self->output_volume_slider), FALSE);
   g_settings_bind (self->sound_settings, "allow-volume-overdrive",
                     self->allow_amplify_switch, "active", G_SETTINGS_BIND_DEFAULT);


### PR DESCRIPTION
Fedora rawhide (41) adds -Wno-incompatible-pointer-types as a default CFLAG, which results in a few parts of the codebase failing to build due to a lack of casting to GTK_WIDGET