### PR TITLE
Don't use gnome-desktop thumbnail preview creator - closes #85

### DIFF
--- a/panels/background/cc-background-chooser.c
+++ b/panels/background/cc-background-chooser.c
@@ -247,8 +247,9 @@ on_file_chooser_selection_changed_cb (GtkFileChooser               *chooser,
       g_autoptr(GdkPixbuf) pixbuf = NULL;
       g_autofree gchar *mime_type = NULL;
       g_autoptr(GFile) file = NULL;
+      g_autofree gchar *filename = NULL;
+
       GtkWidget *preview;
-      GError *error = NULL;
 
       preview = gtk_file_chooser_get_preview_widget (chooser);
 
@@ -264,23 +265,9 @@ on_file_chooser_selection_changed_cb (GtkFileChooser               *chooser,
 
       if (mime_type)
         {
-#if defined(GNOME_DESKTOP_PLATFORM_VERSION) && GNOME_DESKTOP_PLATFORM_VERSION >= 43
-          pixbuf = gnome_desktop_thumbnail_factory_generate_thumbnail (thumbnail_factory,
-                                                                       uri,
-                                                                       mime_type,
-                                                                       NULL,
-                                                                       &error);
+          filename = gtk_file_chooser_get_filename (chooser);
+          pixbuf = gdk_pixbuf_new_from_file_at_size (filename, 128, 128, NULL);
 
-          if (error)
-            {
-              g_warning("could not general thumbnail %s (%s) %s\n", uri, mime_type, error->message);
-              g_clear_error(&error);
-            }
-#else
-          pixbuf = gnome_desktop_thumbnail_factory_generate_thumbnail (thumbnail_factory,
-                                                                       uri,
-                                                                       mime_type);
-#endif
         }
 
       gtk_dialog_set_response_sensitive (GTK_DIALOG (chooser),


### PR DESCRIPTION
## Description
Workaround the deemed insecure usage of gnome-desktop thumbnail preview generator.

By the time this part of the code is reached, all the file & mime-type validations have passed. So just create a image preview using the standard pixbuf routine.

Note GCC uses the GTK4 version of gnome-bg thumbnail generator that does not use the deemed insecure bwrap routine hence why it works just fine. 

### Submitter Checklist

- [ ] Squashed commits with `git rebase -i` (if needed)
- [ ] Built budgie-control-center and verified that the patch worked (if needed)
