### PR TITLE
power: Handle "unknown" power profiles from tuned-ppd

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -1123,6 +1123,10 @@ performance_profile_set_active (CcPowerPanel  *self,
   CcPowerProfile profile = cc_power_profile_from_str (profile_str);
   GtkRadioButton *button;
 
+  /* FIXME: We don't know what to do with unknown profiles */
+  if (profile == CC_POWER_PROFILE_UNKNOWN)
+    return;
+
   button = cc_power_profile_row_get_radio_button (CC_POWER_PROFILE_ROW (self->power_profiles_row[profile]));
   if (!button) {
     g_warning ("Not setting profile '%s' as it doesn't have a widget", profile_str);
@@ -1446,6 +1450,11 @@ setup_power_profiles (CcPowerPanel *self)
                name, variant_lookup_string (profile_variant, "Driver"));
 
       profile = cc_power_profile_from_str (name);
+
+      /* FIXME: We don't know what to do with unknown profiles */
+      if (profile == CC_POWER_PROFILE_UNKNOWN)
+        continue;
+
       row = cc_power_profile_row_new (cc_power_profile_from_str (name));
       g_signal_connect_object (G_OBJECT (row), "button-toggled",
                                G_CALLBACK (power_profile_button_toggled_cb), self,

--- a/panels/power/cc-power-profile-row.c
+++ b/panels/power/cc-power-profile-row.c
@@ -160,7 +160,9 @@ cc_power_profile_from_str (const char *profile)
   if (g_strcmp0 (profile, "performance") == 0)
     return CC_POWER_PROFILE_PERFORMANCE;
 
-  g_assert_not_reached ();
+  g_warning ("Unknown power profile: %s", profile);
+
+  return CC_POWER_PROFILE_UNKNOWN;
 }
 
 const char *

--- a/panels/power/cc-power-profile-row.h
+++ b/panels/power/cc-power-profile-row.h
@@ -30,10 +30,12 @@ G_BEGIN_DECLS
 
 typedef enum
 {
-  CC_POWER_PROFILE_PERFORMANCE = 0,
-  CC_POWER_PROFILE_BALANCED    = 1,
-  CC_POWER_PROFILE_POWER_SAVER = 2,
-  NUM_CC_POWER_PROFILES
+  CC_POWER_PROFILE_PERFORMANCE,
+  CC_POWER_PROFILE_BALANCED,
+  CC_POWER_PROFILE_POWER_SAVER,
+  NUM_CC_POWER_PROFILES,
+  /* The unknown profile is intentionally not counted as a profile. It exists to handle unsupported profiles. */
+  CC_POWER_PROFILE_UNKNOWN
 } CcPowerProfile;
 
 #define CC_TYPE_POWER_PROFILE_ROW (cc_power_profile_row_get_type())


### PR DESCRIPTION
## Description
This change is cherry-picked from gnome-control-center [1], fixing crashes when budgie-control-center is used with TuneD instead of power-profiles-daemon. For more info, see the commit message.

[1] https://gitlab.gnome.org/GNOME/gnome-control-center/-/commit/131c5591fb256050ba9a1983a9a15509e1cfbab6

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
