### PR TITLE
Make building with bluetooth optional - closes #83

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -248,9 +248,6 @@ config_h.set('HAVE_WWAN', host_is_linux,
              description: 'Define to 1 if WWan is available')
 
 if host_is_linux_not_s390
-  # gnome-bluetooth
-  gnome_bluetooth_dep = dependency('gnome-bluetooth-1.0', version: '>= 3.18.2')
-
   libwacom_dep = dependency('libwacom', version: '>= 0.7')
 
   wacom_deps = [
@@ -262,9 +259,17 @@ else
   message('Bluetooth and Wacom panels will not be built (no USB support on this platform)')
   message('Thunderbolt panel will not be built (not supported on this platform)')
 endif
-config_h.set('BUILD_BLUETOOTH', host_is_linux_not_s390,
+
+enable_bluetooth = get_option('bluetooth')
+if host_is_linux_not_s390 and enable_bluetooth
+  with_bluetooth = 1
+  gnome_bluetooth_dep = dependency('gnome-bluetooth-1.0', version: '>= 3.18.2')
+  config_h.set('BUILD_BLUETOOTH', with_bluetooth,
              description: 'Define to 1 to build the Bluetooth panel')
-config_h.set('HAVE_BLUETOOTH', host_is_linux_not_s390,
+else
+  with_bluetooth = 0
+endif
+config_h.set('HAVE_BLUETOOTH', with_bluetooth,
              description: 'Define to 1 if bluetooth support is available')
 config_h.set('BUILD_WACOM', host_is_linux_not_s390,
              description: 'Define to 1 to build the Wacom panel')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,4 @@ option('wayland', type: 'boolean', value: false, description: 'build with Waylan
 option('profile', type: 'combo', choices: ['default','development'], value: 'default')
 option('malcontent', type: 'boolean', value: false, description: 'build with malcontent support')
 option('dark_mode_distributor_logo', type: 'string', description: 'absolute path to distributor logo dark mode variant')
+option('bluetooth', type: 'boolean', value: true, description: 'build with bluetooth support')

--- a/panels/meson.build
+++ b/panels/meson.build
@@ -33,8 +33,11 @@ if host_is_linux
 endif
 
 if host_is_linux_not_s390
+  if enable_bluetooth
+    panels += ['bluetooth']
+  endif
+
   panels += [
-    'bluetooth',
     'thunderbolt',
     'wacom'
   ]


### PR DESCRIPTION
## Description
as per the title - PR hides the bluetooth panel and no longer builds with bluetooth support

default is to build with bluetooth.


### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-control-center and verified that the patch worked (if needed)
