### PR TITLE
Resolve GNOME49 toolchain issues / use of budgie schema for media-keys

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'budgie-control-center', 'c',
-        version : '1.4.0',
+        version : '1.4.1',
         license : 'GPL2+',
   meson_version : '>= 0.53.0'
 )
@@ -121,7 +121,7 @@ gdk_pixbuf_dep = dependency('gdk-pixbuf-2.0', version: '>= 2.23.0')
 gio_dep = dependency('gio-2.0')
 glib_dep = dependency('glib-2.0', version: '>= 2.70.0')
 gnome_desktop_dep = dependency('gnome-desktop-3.0', version: '>= 3.33.4')
-gnome_settings_dep = dependency('gnome-settings-daemon', version: '>= 3.27.90')
+gnome_settings_dep = dependency('gnome-settings-daemon', version: '>= 49.beta')
 #goa_dep = dependency('goa-1.0', version: goa_req_version)
 gsettings_desktop_dep = dependency('gsettings-desktop-schemas', version: '>= 42.alpha')
 libxml_dep = dependency('libxml-2.0')

--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -959,7 +959,7 @@ set_current_output (CcDisplayPanel   *panel,
       if (cc_has_fractional_key())
         {
           lockdown=cc_display_config_get_fractional_scaling (panel->current_config);
-          gtk_widget_set_sensitive(panel->automatic_screen_lock_switch, !lockdown);
+          gtk_widget_set_sensitive(GTK_WIDGET (panel->automatic_screen_lock_switch), !lockdown);
         }
     }
 

--- a/panels/display/cc-display-settings.c
+++ b/panels/display/cc-display-settings.c
@@ -450,7 +450,7 @@ cc_display_settings_rebuild_ui (CcDisplaySettings *self)
                          cc_display_config_get_fractional_scaling (self->config));
 
   gtk_switch_set_active (GTK_SWITCH (self->scale_fractional_switch), cc_display_config_get_fractional_scaling (self->config));
-  gtk_widget_set_visible(self->scale_fractional_row, cc_has_fractional_key());
+  gtk_widget_set_visible(GTK_WIDGET (self->scale_fractional_row), cc_has_fractional_key());
 
   gtk_widget_set_visible (self->underscanning_row,
                           cc_display_monitor_supports_underscanning (self->selected_output) &&

--- a/panels/keyboard/00-multimedia.xml.in
+++ b/panels/keyboard/00-multimedia.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<KeyListEntries group="system" schema="org.gnome.settings-daemon.plugins.media-keys" name="Sound and Media">
+<KeyListEntries group="system" schema="org.buddiesofbudgie.settings-daemon.plugins.media-keys" name="Sound and Media">
 
 	<KeyListEntry name="volume-mute" description="Volume mute/unmute"/>
 

--- a/panels/keyboard/01-launchers.xml.in
+++ b/panels/keyboard/01-launchers.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<KeyListEntries group="system" schema="org.gnome.settings-daemon.plugins.media-keys" name="Launchers">
+<KeyListEntries group="system" schema="org.buddiesofbudgie.settings-daemon.plugins.media-keys" name="Launchers">
 
 	<KeyListEntry name="help" description="Launch help browser"/>
 

--- a/panels/keyboard/01-system.xml.in
+++ b/panels/keyboard/01-system.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<KeyListEntries group="system" schema="org.gnome.settings-daemon.plugins.media-keys" name="System">
+<KeyListEntries group="system" schema="org.buddiesofbudgie.settings-daemon.plugins.media-keys" name="System">
 
 	<KeyListEntry name="logout" description="Log out"/>
 

--- a/panels/keyboard/50-accessibility.xml.in
+++ b/panels/keyboard/50-accessibility.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<KeyListEntries group="system" name="Accessibility" schema="org.gnome.settings-daemon.plugins.media-keys">
+<KeyListEntries group="system" name="Accessibility" schema="org.buddiesofbudgie.settings-daemon.plugins.media-keys">
 
 	<KeyListEntry name="magnifier" description="Turn zoom on or off"/>
 

--- a/panels/keyboard/cc-keyboard-item.c
+++ b/panels/keyboard/cc-keyboard-item.c
@@ -28,7 +28,7 @@
 
 #include "cc-keyboard-item.h"
 
-#define CUSTOM_KEYS_SCHEMA "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
+#define CUSTOM_KEYS_SCHEMA "org.buddiesofbudgie.settings-daemon.plugins.media-keys.custom-keybinding"
 
 struct _CcKeyboardItem
 {

--- a/panels/keyboard/cc-keyboard-manager.c
+++ b/panels/keyboard/cc-keyboard-manager.c
@@ -30,7 +30,7 @@
 #include <gdk/gdkx.h>
 #endif
 
-#define BINDINGS_SCHEMA       "org.gnome.settings-daemon.plugins.media-keys"
+#define BINDINGS_SCHEMA       "org.buddiesofbudgie.settings-daemon.plugins.media-keys"
 #define CUSTOM_SHORTCUTS_ID   "custom"
 
 struct _CcKeyboardManager

--- a/panels/sound/cc-sound-panel.c
+++ b/panels/sound/cc-sound-panel.c
@@ -300,7 +300,7 @@ cc_sound_panel_init (CcSoundPanel *self)
                            G_CONNECT_SWAPPED);
   allow_amplified_changed_cb (self);
 
-  gtk_widget_set_visible(self->budgie_output_listbox, TRUE);
+  gtk_widget_set_visible(GTK_WIDGET (self->budgie_output_listbox), TRUE);
   gtk_widget_set_visible(GTK_WIDGET (self->output_volume_slider), FALSE);
   g_settings_bind (self->sound_settings, "allow-volume-overdrive",
                     self->allow_amplify_switch, "active", G_SETTINGS_BIND_DEFAULT);


### PR DESCRIPTION
GNOME 49 uses an updated toolchain (at least on Ubuntu) that causes compilation issues due to incorrect casting that has been resolved with GCC post our fork point.

More importantly this updates the schema used for our budgie media-keys usage.

As such we need to revise the compilation dependency on gnome-settings-daemon for 49.beta and later.

Also bumped the version for BCC.

We'll backport to main these changes later once budgie-desktop main has been updated with similar changes.

For the moment created a v1.4.x branch to house this change.  We'll probably move to 2.0.0 for wayland stuff in main.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-control-center and verified that the patch worked (if needed)
