### PR TITLE
Disable cheese and bluetooth support options

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,5 @@
 option('ssh', type: 'boolean', value: false, description: 'build with SSH Socket based connection for remote login')
-option('cheese', type: 'boolean', value: true, description: 'build with cheese webcam support')
+option('cheese', type: 'boolean', value: false, description: 'build with cheese webcam support')
 option('documentation', type: 'boolean', value: false, description: 'build documentation')
 option('ibus', type: 'boolean', value: true, description: 'build with IBus support')
 option('privileged_group', type: 'string', value: 'wheel', description: 'name of group that has elevated permissions')
@@ -9,4 +9,4 @@ option('wayland', type: 'boolean', value: false, description: 'build with Waylan
 option('profile', type: 'combo', choices: ['default','development'], value: 'default')
 option('malcontent', type: 'boolean', value: false, description: 'build with malcontent support')
 option('dark_mode_distributor_logo', type: 'string', description: 'absolute path to distributor logo dark mode variant')
-option('bluetooth', type: 'boolean', value: true, description: 'build with bluetooth support')
+option('bluetooth', type: 'boolean', value: false, description: 'build with bluetooth support')


### PR DESCRIPTION
## Description
Both cheese and bluetooth v1 have been deprecated by GNOME.  Distros such as Debian are now removing these unmaintained apps/libraries. As such this PR changes the defaults to not build by default these deprecated features.

By default in Debian and Ubuntu we do not build with these components.  No adverse issues noted.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-control-center and verified that the patch worked (if needed)
