### PR TITLE
fix(panels): include path for gsd-enums changed in GNOME Settings Daemon 50.beta

### DIFF
--- a/panels/power/cc-power-panel.c
+++ b/panels/power/cc-power-panel.c
@@ -23,7 +23,7 @@
 
 #include <libupower-glib/upower.h>
 #include <glib/gi18n.h>
-#include <gnome-settings-daemon/gsd-enums.h>
+#include <gnome-settings-daemon-50/gnome-settings-daemon/gsd-enums.h>
 #include <gio/gdesktopappinfo.h>
 #include <handy.h>
 

--- a/panels/wacom/gsd-enums.h
+++ b/panels/wacom/gsd-enums.h
@@ -4,4 +4,4 @@
  * prefixes this, we need a little help to avoid this
  * one line difference */
 
-#include <gnome-settings-daemon/gsd-enums.h>
+#include <gnome-settings-daemon-50/gnome-settings-daemon/gsd-enums.h>


### PR DESCRIPTION
## Description
GNOME Settings Daemon 50 beta changes the include path for gsd-enum so it is gnome-settings-daemon-MAJOR/gnome-settings-daemon.


### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
