### PR TITLE
cleanup: Remove G_GNUC_CONST for *_get_type functions

### DIFF
--- a/panels/background/meson.build
+++ b/panels/background/meson.build
@@ -44,7 +44,7 @@ common_sources += gnome.mkenums(
   sources: enums_header,
   fhead: '#pragma once\n\n#include <glib-object.h>\n\nG_BEGIN_DECLS\n',
   fprod: '/* enumerations from "@filename@" */\n',
-  vhead: 'GType @enum_name@_get_type (void) G_GNUC_CONST;\n#define G_DESKTOP_TYPE_@ENUMSHORT@ (@enum_name@_get_type())\n',
+  vhead: 'GType @enum_name@_get_type (void);\n#define G_DESKTOP_TYPE_@ENUMSHORT@ (@enum_name@_get_type())\n',
   ftail: 'G_END_DECLS\n'
 )
 

--- a/panels/common/meson.build
+++ b/panels/common/meson.build
@@ -10,7 +10,7 @@ common_sources += gnome.mkenums(
   sources: enums_header,
   fhead: '#pragma once\n\n#include <glib-object.h>\n\nG_BEGIN_DECLS\n',
   fprod: '/* enumerations from "@filename@" */\n',
-  vhead: 'GType @enum_name@_get_type (void) G_GNUC_CONST;\n#define GSD_TYPE_@ENUMSHORT@ (@enum_name@_get_type())\n',
+  vhead: 'GType @enum_name@_get_type (void);\n#define GSD_TYPE_@ENUMSHORT@ (@enum_name@_get_type())\n',
   ftail: 'G_END_DECLS\n'
 )
 

--- a/panels/printers/pp-printer.h
+++ b/panels/printers/pp-printer.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 #define PP_TYPE_PRINTER (pp_printer_get_type ())
 G_DECLARE_FINAL_TYPE (PpPrinter, pp_printer, PP, PRINTER, GObject)
 
-GType        pp_printer_get_type      (void) G_GNUC_CONST;
+GType        pp_printer_get_type      (void);
 
 PpPrinter   *pp_printer_new           (const gchar          *name);
 

--- a/shell/cc-shell.h
+++ b/shell/cc-shell.h
@@ -59,7 +59,7 @@ struct _CcShellInterface
                                            GtkPositionType  position);
 };
 
-GType           cc_shell_get_type                 (void) G_GNUC_CONST;
+GType           cc_shell_get_type                 (void);
 
 CcPanel *       cc_shell_get_active_panel         (CcShell      *shell);
 void            cc_shell_set_active_panel         (CcShell      *shell,


### PR DESCRIPTION
## Description
GLib recently removed G_GNUC_CONST attributes from its *get_type declarations to avoid miscompilations with GCC trunk. This does the same for us, meaning we have one less thing to worry about for the next GCC release.

Ref https://github.com/BuddiesOfBudgie/budgie-session/issues/11
Ref https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223

### Submitter Checklist

- [x] Squashed commits with `git rebase -i` (if needed)
- [x] Built budgie-control-center and verified that the patch worked (if needed)
