### PR TITLE
Remove color and wacom panels due to gnome-rr deprecation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -239,7 +239,7 @@ config_h.set('BUILD_WWAN', host_is_linux,
 config_h.set('HAVE_WWAN', host_is_linux,
              description: 'Define to 1 if WWan is available')
 
-if host_is_linux_not_s390
+if 1==0 # host_is_linux_not_s390 - disable building wacom
   libwacom_dep = dependency('libwacom', version: '>= 0.7')
 
   wacom_deps = [
@@ -252,10 +252,14 @@ else
   message('Thunderbolt panel will not be built (not supported on this platform)')
 endif
 
-config_h.set('BUILD_WACOM', host_is_linux_not_s390,
+#config_h.set('BUILD_WACOM', host_is_linux_not_s390,
+#             description: 'Define to 1 to build the Wacom panel')
+#config_h.set('HAVE_WACOM', host_is_linux_not_s390,
+#             description: 'Define to 1 if Wacom is supportted')
+config_h.set('BUILD_WACOM', false,
              description: 'Define to 1 to build the Wacom panel')
-config_h.set('HAVE_WACOM', host_is_linux_not_s390,
-             description: 'Define to 1 if Wacom is supportted')
+config_h.set('HAVE_WACOM', false,
+             description: 'Define to 1 if Wacom is supported')
 config_h.set('BUILD_THUNDERBOLT', host_is_linux_not_s390,
              description: 'Define to 1 to build the Thunderbolt panel')
 

--- a/panels/meson.build
+++ b/panels/meson.build
@@ -3,8 +3,6 @@ subdir('common')
 panels = [
   'applications',
   'background',
-  'camera',
-  'color',
   'datetime',
   'default-apps',
   'diagnostics',
@@ -37,7 +35,7 @@ endif
 if host_is_linux_not_s390
   panels += [
     'thunderbolt',
-    'wacom'
+    #'wacom'
   ]
 endif
 

--- a/shell/cc-panel-loader.c
+++ b/shell/cc-panel-loader.c
@@ -33,7 +33,6 @@
 /* Extension points */
 extern GType cc_applications_panel_get_type (void);
 extern GType cc_background_panel_get_type (void);
-//extern GType cc_color_panel_get_type (void);
 extern GType cc_date_time_panel_get_type (void);
 extern GType cc_default_apps_panel_get_type (void);
 extern GType cc_info_overview_panel_get_type (void);
@@ -99,8 +98,6 @@ static CcPanelLoaderVtable default_panels[] =
 {
   PANEL_TYPE("applications",     cc_applications_panel_get_type,         NULL),
   PANEL_TYPE("background",       cc_background_panel_get_type,           NULL),
-  //PANEL_TYPE("camera",           cc_camera_panel_get_type,               NULL),
-  //PANEL_TYPE("color",            cc_color_panel_get_type,                NULL),
   PANEL_TYPE("datetime",         cc_date_time_panel_get_type,            NULL),
   PANEL_TYPE("default-apps",     cc_default_apps_panel_get_type,         NULL),
   //PANEL_TYPE("diagnostics",      cc_diagnostics_panel_get_type,          cc_diagnostics_panel_static_init_func),
@@ -118,7 +115,6 @@ static CcPanelLoaderVtable default_panels[] =
   PANEL_TYPE("wifi",             cc_wifi_panel_get_type,                 cc_wifi_panel_static_init_func),
 #endif
   PANEL_TYPE("notifications",    cc_notifications_panel_get_type,        NULL),
-  //PANEL_TYPE("online-accounts",  cc_goa_panel_get_type,                  NULL),
   PANEL_TYPE("power",            cc_power_panel_get_type,                NULL),
   PANEL_TYPE("printers",         cc_printers_panel_get_type,             NULL),
   PANEL_TYPE("region",           cc_region_panel_get_type,               NULL),

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -115,9 +115,9 @@ shell_deps = common_deps + [
   libshell_dep,
 ]
 
-if host_is_linux_not_s390
-  shell_deps += wacom_deps
-endif
+#if host_is_linux_not_s390
+#  shell_deps += wacom_deps
+#endif
 
 executable(
   meson.project_name(),


### PR DESCRIPTION
## Description
Wacom and the color panels depend on the gnome-rr library which has now been removed with libgnome-desktop v51 alpha 

This patch removes build support for wacom and color panels.

Note - previously we just hid the color panel from BCC - this now stops building the code.

Intention here is temporary until we figure out how to rework the wacom code as appropriate.

Tested building against v2.89.2 on ubuntu 26.10 stonking-proposed which holds libgnome-desktop 51 alpha unstable.

Will patch both debian experimental and stonking-proposed to ensure BCC doesn't hold gnome-desktop migration

Closes #118 

Note - online-accounts and camera panel commented code  has also been removed  - full source cleanup is part of #121 

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-control-center and verified that the patch worked (if needed)
