### PR TITLE
keyboard: replace gkbd-keyboard-display with tecla

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "subprojects/gvc"]
 	path = subprojects/gvc
 	url = https://gitlab.gnome.org/GNOME/libgnome-volume-control.git
+[submodule "subprojects/tecla"]
+	path = subprojects/tecla
+	url = https://gitlab.gnome.org/GNOME/tecla.git

--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,22 @@ if not libhandy_dep.found()
   libhandy_dep = libhandy.get_variable('libhandy_dep')
 endif
 
+tecla_dep = dependency(
+  'tecla',
+  version: '>=47.0',
+  required: false
+)
+
+tecla_is_subproject = not tecla_dep.found()
+if tecla_is_subproject
+  tecla = subproject(
+    'tecla',
+    default_options: [
+      'werror=false',
+    ],
+  )
+endif
+
 #goa_req_version = '>= 3.25.3'
 pulse_req_version = '>= 2.0'
 

--- a/panels/keyboard/cc-input-list-box.c
+++ b/panels/keyboard/cc-input-list-box.c
@@ -223,10 +223,10 @@ row_layout_cb (CcInputListBox *self,
   layout_variant = cc_input_source_get_layout_variant (source);
 
   if (layout_variant && layout_variant[0])
-    commandline = g_strdup_printf ("gkbd-keyboard-display -l \"%s\t%s\"",
+    commandline = g_strdup_printf (KEYBOARD_PREVIEWER_EXEC " \"%s+%s\"",
 				   layout, layout_variant);
   else
-    commandline = g_strdup_printf ("gkbd-keyboard-display -l %s",
+    commandline = g_strdup_printf (KEYBOARD_PREVIEWER_EXEC " %s",
 				   layout);
 
   g_spawn_command_line_async (commandline, NULL);

--- a/panels/keyboard/meson.build
+++ b/panels/keyboard/meson.build
@@ -81,12 +81,20 @@ if enable_ibus
   deps += ibus_dep
 endif
 
+if tecla_is_subproject
+  keyboard_previewer_exec = get_option('prefix') / get_option('bindir') / 'tecla'
+else
+  keyboard_previewer_exec = tecla_dep.get_variable('app')
+endif
+
 panels_libs += static_library(
   cappletname,
   sources: sources,
   include_directories: [top_inc, common_inc],
   dependencies: deps,
-  c_args: cflags
+  c_args: cflags + [
+    '-DKEYBOARD_PREVIEWER_EXEC="@0@"'.format(keyboard_previewer_exec)
+  ]
 )
 
 subdir('icons')


### PR DESCRIPTION
Closes #122

This implementation is directly copied from gnome-control-center.

## Description
This replaces use of gkbd-keyboard-display with the modern replacement from GNOME (tecla).

I tested this on NixOS with tecla injected into the build and on Debian where I let Meson just clone the subproject. In both cases hitting the "View Keyboard Layout" button launched tecla with the correct layout displayed.

### Submitter Checklist

- [X] Squashed commits with `git rebase -i` (if needed)
- [X] Built budgie-control-center and verified that the patch worked (if needed)
